### PR TITLE
2020 judging form updates

### DIFF
--- a/form_generator/form_generator.py
+++ b/form_generator/form_generator.py
@@ -429,21 +429,23 @@ if __name__ == "__main__":
         print("I/O error({0}): {1}".format(e.errno, e.strerror))
         sys.exit(2)
 
+    metadata = data['metadata']
     canvas = canvas.Canvas(output_file, pagesize=letter)
     for contestant in data['entries']:
         # Put all of the contestant's entry forms together
         for entry in contestant.get('entries'):
-            generate_entry_form(canvas, contestant.get('signup'), entry, contestant.get('registrant'), data['metadata'])
+            generate_entry_form(canvas, contestant.get('signup'), entry, contestant.get('registrant'), metadata)
             canvas.showPage()
     for contestant in data['entries']:
         # Print R&R form
-        generate_registration_and_release_form(canvas, contestant.get('signup'), contestant.get('registrant'), data['metadata']['divisionals'], data['metadata']['tastings'], data['metadata']['showcases'])
+        generate_registration_and_release_form(canvas, contestant.get('signup'), contestant.get('registrant'), metadata['divisionals'], metadata['tastings'], metadata['showcases'])
         canvas.showPage()
 
         # Put all of the contestant's judging sheets together
         for entry in contestant.get('entries'):
             signup = contestant.get('signup')
-            if ((signup.get('class') != 'Child') and (signup.get('class') != 'Junior')):
-                generate_judging_form(canvas, contestant.get('signup'), entry, data['metadata'])
+            signup_class = signup.get('class')
+            if (signup_class != 'Child' and signup_class != 'Junior') or _is_tasting(metadata, entry):
+                generate_judging_form(canvas, contestant.get('signup'), entry, metadata)
                 canvas.showPage()
     canvas.save()

--- a/form_generator/form_generator.py
+++ b/form_generator/form_generator.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import json
 import sys
 from reportlab.pdfgen import canvas
@@ -20,9 +22,13 @@ def _is_tasting(metadata, entry):
     return entry['category'] in metadata['tastings']
 
 
+def _is_showcake(entry):
+    return entry.get('category').startswith('Showcakes')
+
+
 def generate_judging_form(canvas, signup, entry, metadata):
     header(canvas, signup, entry, metadata)
-    if (entry.get('category').startswith('Showcakes')):
+    if _is_showcake(entry):
         judging_showcake_body(canvas)
     elif _is_tasting(metadata, entry):
         judging_tasting_body(canvas)
@@ -46,7 +52,7 @@ def header(canvas, signup, entry, metadata):
     canvas.setFont("Helvetica-Bold", 20)
     canvas.drawRightString(7.75 * inch, 10 * inch, "Entry #" + str(entry.get('id')))
     canvas.setFont("Helvetica", 12)
-    if (entry.get('category').startswith('Showcakes')):
+    if _is_showcake(entry):
         canvas.drawRightString(7.75 * inch, 9.75 * inch, entry.get('category'))
     elif _is_tasting(metadata, entry):
         canvas.drawRightString(7.75 * inch, 9.75 * inch, entry.get('category'))
@@ -411,7 +417,7 @@ def generate_registration_and_release_form(canvas, signup, registrant, divisiona
 
 if __name__ == "__main__":
     if (len(sys.argv) != 3):
-        print "ERROR: Must provide two parameters: JSON_FILE OUTPUT_FILE"
+        print("ERROR: Must provide two parameters: JSON_FILE OUTPUT_FILE")
         sys.exit(2)
     json_file = str(sys.argv[1])
     output_file = str(sys.argv[2])
@@ -420,7 +426,7 @@ if __name__ == "__main__":
         json_data = open(json_file)
         data = json.load(json_data)
     except IOError as e:
-        print "I/O error({0}): {1}".format(e.errno, e.strerror)
+        print("I/O error({0}): {1}".format(e.errno, e.strerror))
         sys.exit(2)
 
     canvas = canvas.Canvas(output_file, pagesize=letter)

--- a/form_generator/form_generator.py
+++ b/form_generator/form_generator.py
@@ -149,8 +149,15 @@ def judging_divisional_body(canvas):
 
 
 def judging_showcake_body(canvas):
-    criteria = ["Application of Theme", "Precision of Techniques", "Originality & Creativity", "Appropriate Design (size, shape, colors, etc.)", "Difficulty of Techniques", "Number of Techniques Used", "Overall Eye Appeal (Judge's discretion)"]
-    maximum_points = [15, 15, 15, 15, 15, 15, 10]
+    criteria = [
+        ("Application of Theme", 15),
+        ("Precision of Techniques", 15),
+        ("Originality & Creativity", 15),
+        ("Appropriate Design (size, shape, colors, etc.)", 15),
+        ("Difficulty of Techniques", 15),
+        ("Number of Techniques Used", 15),
+        ("Overall Eye Appeal (Judge's discretion)", 10)
+    ]
 
     # Table header
     canvas.drawString(5.85 * inch, 8.375 * inch, "Maximum")
@@ -160,12 +167,10 @@ def judging_showcake_body(canvas):
 
     # Display column of criteria
     offset = 7.75
-    index = 0
-    for criterium in criteria:
+    for criterium, maximum_points in criteria:
         canvas.drawString(1.125 * inch, offset * inch, criterium)
-        canvas.drawString(6.125 * inch, offset * inch, str(maximum_points[index]))
+        canvas.drawString(6.125 * inch, offset * inch, str(maximum_points))
         offset -= 0.375
-        index += 1
     canvas.drawString(6.125 * inch, offset * inch, "Total:")
 
     # Build up rows
@@ -192,8 +197,14 @@ def judging_showcake_body(canvas):
 
 
 def judging_tasting_body(canvas):
-    criteria = ["Flavor", "Crumb", "Texture", "Density", "Appearance", "Theme"]
-    maximum_points = [40, 10, 10, 10, 15, 15]
+    criteria = [
+        ("Flavor", 40),
+        ("Crumb", 10),
+        ("Texture", 10),
+        ("Density", 10),
+        ("Appearance", 15),
+        ("Theme", 15)
+    ]
 
     # Table header
     canvas.drawString(5.85 * inch, 8.375 * inch, "Maximum")
@@ -203,12 +214,10 @@ def judging_tasting_body(canvas):
 
     # Display column of criteria
     offset = 7.75
-    index = 0
-    for criterium in criteria:
+    for criterium, maximum_points in criteria:
         canvas.drawString(1.125 * inch, offset * inch, criterium)
-        canvas.drawString(6.125 * inch, offset * inch, str(maximum_points[index]))
+        canvas.drawString(6.125 * inch, offset * inch, str(maximum_points))
         offset -= 0.375
-        index += 1
     canvas.drawString(6.125 * inch, offset * inch, "Total:")
 
     # Build up rows

--- a/form_generator/form_generator.py
+++ b/form_generator/form_generator.py
@@ -23,7 +23,7 @@ def _is_tasting(metadata, entry):
 
 
 def _is_showcake(entry):
-    return entry.get('category').startswith('Showcakes')
+    return entry.get('category').startswith('Showpiece')
 
 
 def header(canvas, signup, entry, metadata):
@@ -157,6 +157,10 @@ def generate_judging_form(canvas, signup, entry, metadata):
         judging_showcake_body(canvas)
     elif _is_tasting(metadata, entry):
         judging_tasting_body(canvas)
+    elif entry['category'] == '3D Cookie':
+        three_d_cookie_body(canvas)
+    elif entry['category'] == '2D Cookie':
+        two_d_cookie_body(canvas)
     else:
         judging_divisional_body(canvas)
 
@@ -211,6 +215,43 @@ def judging_tasting_body(canvas):
                     ("Density", 10),
                     ("Appearance", 15),
                     ("Theme", 15)
+                ]),
+                spacer(0.5),
+            comments(1.5)
+        ])
+
+def three_d_cookie_body(canvas):
+    draw_page(
+        canvas, 8.375,
+        [
+                judging_criteria([
+                    ("Interpretation of Theme", 10),
+                    ("Number & Diff of Decorating Techniques Used", 10),
+                    ("Number & Diff of Construction Techniques Used", 10),
+                    ("Mastery of Techniques Used", 10),
+                    ("Cleanliness of Individual Elements and Constr.", 10),
+                    ("Scale, Balance and Viewability of 3D Construction", 10),
+                    ("Originality of Design", 10),
+                    ("Setup/Display", 10),
+                    ("Overall Appeal", 10),
+                ]),
+                spacer(0.5),
+            comments(1.5)
+        ])
+
+
+def two_d_cookie_body(canvas):
+    draw_page(
+        canvas, 8.375,
+        [
+                judging_criteria([
+                    ("Interpretation of Theme", 10),
+                    ("Number & Diff of Decorating Techniques Used", 10),
+                    ("Mastery of Techniques Used", 10),
+                    ("Cleanliness of Icing/Covering & Cookies", 10),
+                    ("Originality of Design", 10),
+                    ("Setup/Display", 10),
+                    ("Overall Appeal", 10),
                 ]),
                 spacer(0.5),
             comments(1.5)

--- a/shared/data_types.coffee
+++ b/shared/data_types.coffee
@@ -175,9 +175,7 @@ exports.entryNames =
     junior: 'Junior'
   '2020':
     showcase: 'Showpiece Sculpted Indiv'
-    showcase2: 'Showpiece Sculpted Team'
     showcase3: 'Showpiece Tiered Indi'
-    showcase4: 'Showpiece Tiered Team'
     style1: 'Novelty Single'
     style2: 'Sculpted'
     style3: 'Novelty Tiered'


### PR DESCRIPTION
This updates the judging forms for 2020. Since there were two new custom judging forms in the divisional competition, I refactored the judging form generation code to make it easier to re-use bits of it between different forms.

It also fixes a few bugs:

1. Showcase cakes were getting the divisional judging forms, instead of the showcase cake judging forms.
1. Child and Junior testing entries weren't getting judging forms; now they will.
1. Removed the Team showcase sections from the forms for 2020.